### PR TITLE
Added `e.ListN()` and `d.ListN()`

### DIFF
--- a/docs/pages/data-encoding.mdx
+++ b/docs/pages/data-encoding.mdx
@@ -72,6 +72,14 @@ pub struct Data<M: ManagedTypeApi> {
 }
 ```
 
+### e.ListN
+
+- This functionality operates similarly to `e.Tuple` but introduces a specialized `d.ListN(listLength, T)` feature designed for decoding fixed arrays. It enables us to expressively write `d.ListN(5, d.U8())` as a concise alternative to the more verbose `d.Tuple(d.U8(), d.U8(), d.U8(), d.U8(), d.U8())` when performing decoding operations.
+
+```rust
+pub fixed_array: [u8; 5],
+```
+
 ### e.List
 
 - Encodes an array of values for use with vector data types such as `ManagedVec`, `MultiValueManagedVec` or `MultiValueEncoded`. Uses nest encoding for the underlying data. Adds the length of the array at the beginning when it is itself nest encoded i.e. as part of a `Tuple`.
@@ -97,22 +105,11 @@ await deployer.callContract({
     e.Buffer("0101"),
     deployer,
     e.Option(null),
-    e.Tuple(
-      e.U32(2),
-      e.List(e.U64(1), e.U64(2)),
-    ),
+    e.Tuple(e.U32(2), e.List(e.U64(1), e.U64(2))),
     e.List(
-      e.Tuple(
-        e.Str("TOKEN-123456"),
-        e.U32(BigInt(1)),
-        e.U(BigInt(3)),
-      ),
-      e.Tuple(
-        e.Str("TOKEN2-123456"),
-        e.U32(BigInt(2)),
-        e.U(BigInt(4)),
-      ),
-    )
+      e.Tuple(e.Str("TOKEN-123456"), e.U32(BigInt(1)), e.U(BigInt(3))),
+      e.Tuple(e.Str("TOKEN2-123456"), e.U32(BigInt(2)), e.U(BigInt(4))),
+    ),
   ],
 });
 ```
@@ -163,18 +160,12 @@ assertAccount(account, {
 
     e.kvs.Mapper("tokens").UnorderedSet([e.Str("TOKEN-123456")]),
 
-    e.kvs.Mapper("positions", e.Addr(address), e.Str("TOKEN-123456")).Vec([
-      e.Tuple(
-        e.Str("NAME1"),
-        e.U32(BigInt(1)),
-        e.U(BigInt(3)),
-      ),
-      e.Tuple(
-        e.Str("NAME2"),
-        e.U32(BigInt(2)),
-        e.U(BigInt(4)),
-      ),
-    ]),
+    e.kvs
+      .Mapper("positions", e.Addr(address), e.Str("TOKEN-123456"))
+      .Vec([
+        e.Tuple(e.Str("NAME1"), e.U32(BigInt(1)), e.U(BigInt(3))),
+        e.Tuple(e.Str("NAME2"), e.U32(BigInt(2)), e.U(BigInt(4))),
+      ]),
   ],
 });
 ```
@@ -213,8 +204,19 @@ assertAccount(account, {
     e.kvs.Esdts([
       { id: "TOKEN-123456", amount: 2_000 },
       { id: "NFT-123456", nonce: 1, name: "Nft Name", uris: ["url"] },
-      { id: "SFT-123456", nonce: 1, amount: 3_000, name: "Sft Name", uris: ["url"] },
-      { id: "META-123456", nonce: 1, amount: 3_000, attrs: e.Tuple(e.Str("test")) },
+      {
+        id: "SFT-123456",
+        nonce: 1,
+        amount: 3_000,
+        name: "Sft Name",
+        uris: ["url"],
+      },
+      {
+        id: "META-123456",
+        nonce: 1,
+        amount: 3_000,
+        attrs: e.Tuple(e.Str("test")),
+      },
     ]),
   ],
 });

--- a/xsuite/src/data/ListNDecoder.ts
+++ b/xsuite/src/data/ListNDecoder.ts
@@ -1,0 +1,29 @@
+import { ByteReader } from "./ByteReader";
+import { AbstractDecoder, Decoder } from "./Decoder";
+
+export class ListNDecoder<T> extends AbstractDecoder<T[]> {
+  length: number;
+  #decoder: Decoder<T>;
+
+  constructor(length: number, decoder: Decoder<T>) {
+    super();
+    this.length = length;
+    this.#decoder = decoder;
+  }
+
+  _fromTop(r: ByteReader) {
+    const result = [];
+    while (!r.isConsumed()) {
+      result.push(this.#decoder.fromNest(r));
+    }
+    return result;
+  }
+
+  _fromNest(r: ByteReader) {
+    const result = [];
+    for (let i = 0; i < this.length; i++) {
+      result.push(this.#decoder.fromNest(r));
+    }
+    return result;
+  }
+}

--- a/xsuite/src/data/decoding.ts
+++ b/xsuite/src/data/decoding.ts
@@ -4,6 +4,7 @@ import { BytesDecoder } from "./BytesDecoder";
 import { Decoder, isDecoder } from "./Decoder";
 import { IntDecoder } from "./IntDecoder";
 import { ListDecoder } from "./ListDecoder";
+import { ListNDecoder } from "./ListNDecoder";
 import { OptionDecoder } from "./OptionDecoder";
 import { TupleDecoderList, TupleDecoderMap } from "./TupleDecoder";
 import { UintDecoder } from "./UintDecoder";
@@ -85,6 +86,9 @@ export const d = {
     return d.TopBuffer().then((b) => d.I().fromTop(b));
   },
   Tuple,
+  ListN: <T>(length: number, decoder: Decoder<T>) => {
+    return new ListNDecoder(length, decoder);
+  },
   List: <T>(decoder: Decoder<T>) => {
     return new ListDecoder(decoder);
   },

--- a/xsuite/src/data/encoding.ts
+++ b/xsuite/src/data/encoding.ts
@@ -97,6 +97,9 @@ export const e = {
   Tuple: (...values: Encodable[]) => {
     return new TupleEncodable(values);
   },
+  ListN: (...values: Encodable[]) => {
+    return new TupleEncodable(values);
+  },
   List: (...values: Encodable[]) => {
     return new ListEncodable(values);
   },

--- a/xsuite/src/data/index.test.ts
+++ b/xsuite/src/data/index.test.ts
@@ -432,6 +432,26 @@ test("e.Tuple.toNestHex - e.U8 + e.U16", () => {
   expect(e.Tuple(e.U8(1), e.U16(2)).toNestHex()).toEqual("010002");
 });
 
+test("e.ListN.toTopHex - length 2", () => {
+  expect(e.ListN(e.U8(1), e.U8(2)).toTopHex()).toEqual("0102");
+});
+
+test("e.ListN.toNestHex - length 2", () => {
+  expect(e.ListN(e.U8(1), e.U8(2)).toNestHex()).toEqual("0102");
+});
+
+test("e.ListN.toTopHex - length 5", () => {
+  expect(
+    e.ListN(e.U8(0), e.U8(1), e.U8(2), e.U8(3), e.U8(4)).toTopHex(),
+  ).toEqual("0001020304");
+});
+
+test("e.ListN.toNestHex - length 5", () => {
+  expect(
+    e.ListN(e.U8(0), e.U8(1), e.U8(2), e.U8(3), e.U8(4)).toNestHex(),
+  ).toEqual("0001020304");
+});
+
 test("e.List.toTopHex - e.U8 + e.U8", () => {
   expect(e.List(e.U8(1), e.U8(2)).toTopHex()).toEqual("0102");
 });
@@ -1112,6 +1132,34 @@ test("d.List.fromNest - empty array", () => {
 
 test("d.List.fromNest - non-empty array", () => {
   expect(d.List(d.U8()).fromNest("000000020102")).toEqual([1n, 2n]);
+});
+
+test("d.ListN.fromTop - lenght 2", () => {
+  expect(d.ListN(2, d.U8()).fromTop("0102")).toEqual([1n, 2n]);
+});
+
+test("d.ListN.fromNest - lenght 2", () => {
+  expect(d.ListN(2, d.U8()).fromNest("0102")).toEqual([1n, 2n]);
+});
+
+test("d.ListN.fromTop - lenght 5", () => {
+  expect(d.ListN(5, d.U8()).fromTop("0001020304")).toEqual([
+    0n,
+    1n,
+    2n,
+    3n,
+    4n,
+  ]);
+});
+
+test("d.ListN.fromNest - length 5", () => {
+  expect(d.ListN(5, d.U8()).fromNest("0001020304")).toEqual([
+    0n,
+    1n,
+    2n,
+    3n,
+    4n,
+  ]);
 });
 
 test("d.Option.fromTop - null of BigUint", () => {


### PR DESCRIPTION
## Example usage:

```rs
// to encode / decode the following rust data type:
pub fixed_array: [u8; 3],
```

```ts
// decoding
d.ListN(3, u.U8( ));
// encoding
e.ListN(e.U8(100), e.U8(100), e.U8(200));
```